### PR TITLE
Token-level CodeSearchNet preprocessing option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ env.sh
 .mypy_cache
 notebooks/output
 notebooks/repos
-.venv/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ env.sh
 .mypy_cache
 notebooks/output
 notebooks/repos
+.venv/
+.vscode/

--- a/notebooks/codesearchnet-opennmt.py
+++ b/notebooks/codesearchnet-opennmt.py
@@ -176,7 +176,7 @@ def main(args: Namespace) -> None:
 if __name__ == "__main__":
     parser = ArgumentParser(add_help=False)
     parser.add_argument(
-        "--data_dir",
+        "--data-dir",
         type=str,
         default="java/final/jsonl/test",
         help="Path to the unziped input data (CodeSearchNet)",

--- a/notebooks/codesearchnet-opennmt.py
+++ b/notebooks/codesearchnet-opennmt.py
@@ -6,7 +6,7 @@ Usage example:
     wget 'https://s3.amazonaws.com/code-search-net/CodeSearchNet/v2/java.zip'
     unzip java.zip
     python notebooks/codesearchnet-opennmt.py \
-        --data_dir='java/final/jsonl/valid' \
+        --data-dir='java/final/jsonl/valid' \
         --newline='\\n'
 """
 from argparse import ArgumentParser, Namespace
@@ -20,8 +20,13 @@ import pandas as pd
 
 logging.basicConfig(level=logging.INFO)
 
+# catch SIGPIPE to make it nix CLI friendly e.g. | head
+from signal import signal, SIGPIPE, SIG_DFL
 
-class CodeSearchNetRAM(object):
+signal(SIGPIPE, SIG_DFL)
+
+
+class CodeSearchNetRAM:
     """Stores one split of CodeSearchNet data in memory"""
 
     def __init__(self, split_path: Path, newline_repl: str):
@@ -64,13 +69,10 @@ class CodeSearchNetRAM(object):
 
         # drop fn signature
         code = row["code"]
-        fn_body = (
-            code[
-                code.find("{", code.find(fn_name) + len(fn_name)) + 1 : code.rfind("}")
-            ]
-            .lstrip()
-            .rstrip()
-        )
+        fn_body = code[
+            code.find("{", code.find(fn_name) + len(fn_name)) + 1 : code.rfind("}")
+        ]
+        fn_body = fn_body.strip()
         fn_body = fn_body.replace("\n", self.newline_repl)
         # fn_body_enc = self.enc.encode(fn_body)
 
@@ -111,9 +113,7 @@ if __name__ == "__main__":
         help="Path to the unziped input data (CodeSearchNet)",
     )
 
-    parser.add_argument(
-        "--newline", type=str, default="\\n", help="Replace newline with this"
-    )
+    parser.add_argument("--newline", default="\\n", help="Replace newline with this")
 
     parser.add_argument(
         "--token-level-sources",
@@ -128,14 +128,11 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--src_file",
-        type=str,
-        default="src-%s.token",
-        help="File with function bodies",
+        "--src-file", default="src-%s.token", help="File with function bodies",
     )
 
     parser.add_argument(
-        "--tgt_file", type=str, default="tgt-%s.token", help="File with function texts"
+        "--tgt-file", default="tgt-%s.token", help="File with function texts"
     )
 
     parser.add_argument(

--- a/notebooks/codesearchnet-opennmt.py
+++ b/notebooks/codesearchnet-opennmt.py
@@ -203,11 +203,11 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--src-file", default="src-%s.token", help="File with function bodies",
+        "--src-file", default="src-%s.txt", help="File with function bodies",
     )
 
     parser.add_argument(
-        "--tgt-file", default="tgt-%s.token", help="File with function texts"
+        "--tgt-file", default="tgt-%s.txt", help="File with function texts"
     )
 
     parser.add_argument(


### PR DESCRIPTION
Add ` --token-level-sources` and `--print` options that would result in 

token-level sources, used to reproduce OpenNMT seq2seq baseline from literature
```
'fastPathOrderedEmit                     ' - 'final Observer < ? super V > observer = '
'amb                                     ' - 'ObjectHelper . requireNonNull ( sources '
'ambArray                                ' - 'ObjectHelper . requireNonNull ( sources '
'concat                                  ' - 'ObjectHelper . requireNonNull ( sources '
'concat                                  ' - 'ObjectHelper . requireNonNull ( sources '
'concatArray                             ' - 'if ( sources . length == 0 ) { return em'
'concatArrayDelayError                   ' - 'if ( sources . length == 0 ) { return em'
'concatArrayEager                        ' - 'return concatArrayEager ( bufferSize ( )'
'concatArrayEager                        ' - 'return fromArray ( sources ) . concatMap'
'concatArrayEagerDelayError              ' - 'return fromArray ( sources ) . concatMap'
```

word-level source and char-level target (default)
```
'f a s t P a t h O r d e r e d E m i t   ' - 'final Observer<? super V> observer = dow'
'a m b                                   ' - 'ObjectHelper.requireNonNull(sources, "so'
'a m b A r r a y                         ' - 'ObjectHelper.requireNonNull(sources, "so'
'c o n c a t                             ' - 'ObjectHelper.requireNonNull(sources, "so'
'c o n c a t                             ' - 'ObjectHelper.requireNonNull(sources, "so'
'c o n c a t A r r a y                   ' - 'if (sources.length == 0) {\n            '
'c o n c a t A r r a y D e l a y E r r o ' - 'if (sources.length == 0) {\n            '
'c o n c a t A r r a y E a g e r         ' - 'return concatArrayEager(bufferSize(), bu'
'c o n c a t A r r a y E a g e r         ' - 'return fromArray(sources).concatMapEager'
'c o n c a t A r r a y E a g e r D e l a ' - 'return fromArray(sources).concatMapEager'
```

after 6cfc883 - token-level source and target

```
'fast path ordered emit                  ' - 'final Observer < ? super V > observer = '
'amb                                     ' - 'ObjectHelper . requireNonNull ( sources '
'amb array                               ' - 'ObjectHelper . requireNonNull ( sources '
'concat                                  ' - 'ObjectHelper . requireNonNull ( sources '
'concat                                  ' - 'ObjectHelper . requireNonNull ( sources '
'concat array                            ' - 'if ( sources . length == 0 ) { return em'
'concat array delay error                ' - 'if ( sources . length == 0 ) { return em'
'concat array eager                      ' - 'return concatArrayEager ( bufferSize ( )'
'concat array eager                      ' - 'return fromArray ( sources ) . concatMap'
'concat array eager delay error          ' - 'return fromArray ( sources ) . concatMap'
```

External dependencies like PyTorch (or https://github.com/microsoft/dpu-utils) are dropped for the CLI helper as it does not use it in any way (but implement a similar interface)